### PR TITLE
Feat: 할 일(Todo) 완료 상태(isDone) 변경 기능 구현 및  API 연동

### DIFF
--- a/backend/src/main/java/com/plands/backend/controller/TodoController.java
+++ b/backend/src/main/java/com/plands/backend/controller/TodoController.java
@@ -1,6 +1,7 @@
 package com.plands.backend.controller;
 
 import com.plands.backend.dto.request.TodoRequestDto;
+import com.plands.backend.dto.request.TodoStatusRequestDto;
 import com.plands.backend.dto.response.CalendarResponseDto;
 import com.plands.backend.dto.response.TodoTypeResponseDto;
 import com.plands.backend.service.CalendarService;
@@ -96,6 +97,22 @@ public class TodoController {
         todoService.modifyTodo(todoId, todoRequestDto);
 
         return ResponseEntity.ok("할 일이 성공적으로 수정되었습니다.");
+    }
+
+    // 할 일 완료 상태 변경 API
+    @PatchMapping("/{todoId}/status")
+    public ResponseEntity<Void> updateTodoStatus(
+            @PathVariable Long todoId,
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestBody TodoStatusRequestDto requestDto) {
+        log.info("====== 할 일 완료 상태 변경 컨트롤러 진입 ======");
+        log.debug("상태를 변경할 할 일 ID: {}", todoId);
+
+        Long memberId = getAuthenticatedMemberId(userDetails);
+
+        todoService.modifyTodoStatus(todoId, memberId, requestDto.getIsDone());
+
+        return ResponseEntity.ok().build();
     }
 
     // 할 일 삭제 API (Soft Delete)

--- a/backend/src/main/java/com/plands/backend/dto/request/TodoStatusRequestDto.java
+++ b/backend/src/main/java/com/plands/backend/dto/request/TodoStatusRequestDto.java
@@ -1,0 +1,8 @@
+package com.plands.backend.dto.request;
+
+import lombok.*;
+
+@Getter
+public class TodoStatusRequestDto {
+    private Boolean isDone;
+}

--- a/backend/src/main/java/com/plands/backend/dto/response/CalendarResponseDto.java
+++ b/backend/src/main/java/com/plands/backend/dto/response/CalendarResponseDto.java
@@ -13,6 +13,7 @@ public class CalendarResponseDto {
     private Long id;            // 할 일 고유 번호
     private String title;       // 할 일 종류 이름 (ex: 물주기, 분갈이)
     private String start;       // 할 일 날짜 (due_date)
+    private Boolean isDone;     // 완료 여부
     private String color;       // 카테고리 색상 코드
     private Long todoTypeId;    // 할 일 종류 고유 번호
 

--- a/backend/src/main/java/com/plands/backend/mapper/TodoMapper.java
+++ b/backend/src/main/java/com/plands/backend/mapper/TodoMapper.java
@@ -37,6 +37,13 @@ public interface TodoMapper {
     // 할 일 마스터 데이터 수정 쿼리 호출용
     int updateTodo(TodoRequestDto todoRequestDto);
 
+    // 할 일 완료 상태 변경
+    int updateTodoStatus(
+            @Param("todoId") Long todoId,
+            @Param("memberId") Long memberId,
+            @Param("isDone") Boolean isDone
+    );
+
     // 할 일 마스터 상태 논리 삭제 (is_deleted = 1로 변경)
     int updateTodoIsDeleted(@Param("todoId") Long todoId);
 

--- a/backend/src/main/java/com/plands/backend/mapper/TodoMapper.java
+++ b/backend/src/main/java/com/plands/backend/mapper/TodoMapper.java
@@ -34,12 +34,12 @@ public interface TodoMapper {
     // 특정 회원의 식물 목록 조회
     List<MemberPlantResponseDto> selectMemberPlants(@Param("memberId") Long memberId); // 매개변수가 하나라 @Param 안써도 됨. 2개이상 시 필수
 
+    // 할 일 마스터 데이터 수정 쿼리 호출용
+    int updateTodo(TodoRequestDto todoRequestDto);
+
     // 할 일 마스터 상태 논리 삭제 (is_deleted = 1로 변경)
     int updateTodoIsDeleted(@Param("todoId") Long todoId);
 
     // 할 일 매핑 데이터 완전 삭제 (Hard Delete)
     int deleteTodoMemberPlant(@Param("todoId") Long todoId);
-
-    // 할 일 마스터 데이터 수정 쿼리 호출용
-    int updateTodo(TodoRequestDto todoRequestDto);
 }

--- a/backend/src/main/java/com/plands/backend/service/TodoService.java
+++ b/backend/src/main/java/com/plands/backend/service/TodoService.java
@@ -16,9 +16,9 @@ public interface TodoService {
     // 특정 회원의 식물 목록 조회
     List<MemberPlantResponseDto> findMemberPlantList(Long memberId);
 
-    // 할 일 삭제 비즈니스 로직 (Soft Delete)
-    void removeTodo(Long todoId, Long memberId);
-
     // 할 일 수정
     void modifyTodo(Long todoId, TodoRequestDto todoRequestDto);
+
+    // 할 일 삭제 비즈니스 로직 (Soft Delete)
+    void removeTodo(Long todoId, Long memberId);
 }

--- a/backend/src/main/java/com/plands/backend/service/TodoService.java
+++ b/backend/src/main/java/com/plands/backend/service/TodoService.java
@@ -19,6 +19,9 @@ public interface TodoService {
     // 할 일 수정
     void modifyTodo(Long todoId, TodoRequestDto todoRequestDto);
 
+    // 할 일 완료 상태 변경
+    void modifyTodoStatus(Long todoId, Long memberId, Boolean isDone);
+
     // 할 일 삭제 비즈니스 로직 (Soft Delete)
     void removeTodo(Long todoId, Long memberId);
 }

--- a/backend/src/main/java/com/plands/backend/service/TodoServiceImpl.java
+++ b/backend/src/main/java/com/plands/backend/service/TodoServiceImpl.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 
 @Slf4j // 💡 롬복 로깅 어노테이션 적용
 @Service
@@ -92,8 +93,30 @@ public class TodoServiceImpl implements TodoService {
         log.info("====== 할 일 수정 및 식물 재매핑 완료 ======");
     }
 
+    /**
+     * 할 일 완료 상태 변경
+     */
     @Override
-    @Transactional // 💡 마스터 수정과 매핑 삭제가 한 세트로 묶여야 하므로 트랜잭션 필수!
+    @Transactional
+    public void modifyTodoStatus(Long todoId, Long memberId, Boolean isDone) {
+        log.info("====== 할 일 완료 상태 변경 서비스 진입 ======");
+        log.debug("todoId: {}, memberId: {}, isDone: {}", todoId, memberId, isDone);
+
+        if (isDone == null) {
+            throw new IllegalArgumentException("완료 상태(isDone) 값은 필수입니다.");
+        }
+
+        int affectedRows = todoMapper.updateTodoStatus(todoId, memberId, isDone);
+
+        if (affectedRows == 0) {
+            throw new NoSuchElementException("해당 할 일을 찾을 수 없거나 수정 권한이 없습니다.");
+        }
+
+        log.info("할 일 완료 상태 변경 성공 (todoId: {}, isDone: {})", todoId, isDone);
+    }
+
+    @Override
+    @Transactional
     public void removeTodo(Long todoId, Long memberId) {
         log.info("====== 할 일 삭제 서비스 레이어 진입 (todoId: {}) ======", todoId);
 

--- a/backend/src/main/resources/mappers/TodoMapper.xml
+++ b/backend/src/main/resources/mappers/TodoMapper.xml
@@ -53,6 +53,7 @@
         SELECT
             t.todo_id,
             t.due_date,
+            t.is_done,
             tt.todo_type_id,
             tt.name AS todo_type_name,
             tt.color_code,

--- a/backend/src/main/resources/mappers/TodoMapper.xml
+++ b/backend/src/main/resources/mappers/TodoMapper.xml
@@ -13,6 +13,8 @@
         <result property="color" column="color_code"/>
         <result property="todoTypeId" column="todo_type_id"/>
 
+        <result property="isDone" column="is_done"/>
+
         <collection property="plants" ofType="com.plands.backend.dto.response.PlantInfoDto">
             <result property="memberPlantId" column="member_plant_id"/>
             <result property="plantName" column="plant_name"/>

--- a/backend/src/main/resources/mappers/TodoMapper.xml
+++ b/backend/src/main/resources/mappers/TodoMapper.xml
@@ -127,7 +127,17 @@
             todo_type_id = #{todoTypeId},
             due_date = #{dueDate}
         WHERE todo_id = #{todoId}
-        AND is_deleted = 0
+          AND is_deleted = 0
+    </update>
+
+    <!-- 할 일 완료 상태 변경 -->
+    <update id="updateTodoStatus">
+        UPDATE todo
+        SET
+            is_done = #{isDone}
+        WHERE todo_id = #{todoId}
+          AND member_id = #{memberId}
+          AND is_deleted = 0
     </update>
 
     <!-- ================================================================= -->

--- a/backend/src/test/java/com/plands/backend/service/TodoServiceTest.java
+++ b/backend/src/test/java/com/plands/backend/service/TodoServiceTest.java
@@ -66,4 +66,32 @@ public class TodoServiceTest {
         // DTO 필드명이 isDone (혹은 is_done 매핑 방식)에 맞춰 호출해주세요
         assertThat(targetTodo.getIsDone()).isFalse(); // 또는 0 검증
     }
+
+    @Test
+    @DisplayName("할 일 완료 상태 변경 테스트")
+    void changeTodoStatusTest() {
+        // given
+        Long memberId = 1L;
+        Long todoId = 64L;
+        Boolean isDone = true;
+
+        // when & then - 💡 예외가 발생하지 않고 무사히 실행되는지 검증
+        org.assertj.core.api.Assertions.assertThatCode(() ->
+                todoService.modifyTodoStatus(todoId, memberId, isDone)
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("권한이 없는 유저가 상태 변경 시 예외 발생")
+    void changeTodoStatus_Forbidden_Test() {
+        // given
+        Long wrongMemberId = 999L; // 존재하지 않는 유저 ID
+        Long todoId = 64L;
+        Boolean isDone = true;
+
+        // when & then - 💡 NoSuchElementException 예외가 정상적으로 터지는지 검증
+        org.assertj.core.api.Assertions.assertThatThrownBy(() ->
+                todoService.modifyTodoStatus(todoId, wrongMemberId, isDone)
+        ).isInstanceOf(java.util.NoSuchElementException.class);
+    }
 }

--- a/backend/src/test/java/com/plands/backend/service/TodoServiceTest.java
+++ b/backend/src/test/java/com/plands/backend/service/TodoServiceTest.java
@@ -35,7 +35,7 @@ public class TodoServiceTest {
 
         todoRequestDto.setMemberId(memberId);
         todoRequestDto.setTodoTypeId(1L);
-        todoRequestDto.setDueDate("2026-08-08");
+        todoRequestDto.setDueDate("2026-08-18");
 
         List<Long> memberPlantIds = new ArrayList<>();
         memberPlantIds.add(1L);
@@ -51,9 +51,19 @@ public class TodoServiceTest {
         List<CalendarResponseDto> calendarList = calendarService.findCalendarList(memberId, startDate, endDate);
 
         // then: 4. 검증
+        // 1) 2026-08-18 날짜의 할 일이 조회되는지 확인
         boolean hasTodayTodo = calendarList.stream()
-                .anyMatch(calendar -> calendar.getStart().equals("2026-08-08"));
+                .anyMatch(calendar -> calendar.getStart().equals("2026-08-18"));
 
         assertThat(hasTodayTodo).isTrue();
+
+        // 2) 새로 추가한 is_done(또는 isDone) 값이 정상적으로 가져와졌는지(기본값 0/false) 확인
+        CalendarResponseDto targetTodo = calendarList.stream()
+                .filter(calendar -> calendar.getStart().equals("2026-08-18"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("테스트용 할 일을 찾을 수 없습니다."));
+
+        // DTO 필드명이 isDone (혹은 is_done 매핑 방식)에 맞춰 호출해주세요
+        assertThat(targetTodo.getIsDone()).isFalse(); // 또는 0 검증
     }
 }

--- a/frontend/src/components/my-calendar/DailySchedule.vue
+++ b/frontend/src/components/my-calendar/DailySchedule.vue
@@ -15,11 +15,19 @@ const props = defineProps({
 })
 
 // 💡 부모에게 신호를 보내기 위한 emit 정의
-const emit = defineEmits(['open-register', 'edit-todo', 'delete-todo'])
+const emit = defineEmits(['open-register', 'edit-todo', 'delete-todo', 'toggle-todo'])
 
 const formattedDate = computed(() => {
   return format(props.selectedDate, 'yyyy년 M월 d일 (EEE)', { locale: ko })
 })
+
+// 체크박스 클릭 핸들러
+const onToggleTodo = (event, e) => {
+  emit('toggle-todo', {
+    todoId: event.id,
+    isDone: e.target.checked,
+  })
+}
 
 // 수정 버튼 클릭 시 작동 함수
 const clickEditTodo = (eventObj) => {
@@ -46,8 +54,17 @@ const clickDeletedTodo = (todoId) => {
       <li v-for="event in events" :key="event.id" class="schedule-item">
         <div class="item-main-wrapper">
           <div class="item-header">
+            <input
+              type="checkbox"
+              class="todo-checkbox"
+              :checked="event.isDone"
+              @change="onToggleTodo(event, $event)"
+            />
             <span class="color-badge" :style="{ backgroundColor: event.color }"></span>
-            <strong class="event-title">{{ event.title }}</strong>
+
+            <strong class="event-title" :class="{ completed: event.isDone }">
+              {{ event.title }}
+            </strong>
           </div>
 
           <div class="button-group">
@@ -58,7 +75,11 @@ const clickDeletedTodo = (todoId) => {
           </div>
         </div>
 
-        <div v-if="event.plants && event.plants.length > 0" class="plant-list">
+        <div
+          v-if="event.plants && event.plants.length > 0"
+          class="plant-list"
+          :class="{ completed: event.isDone }"
+        >
           <span v-for="(plant, index) in event.plants" :key="index" class="plant-badge">
             🌿 {{ plant.plantName }}
           </span>
@@ -118,7 +139,7 @@ li.schedule-item {
   border-radius: 6px;
 
   /* 🌟 수정 포인트: 뚜렷한 테두리와 은은한 그림자 추가 */
-  border: 1px solid #edf2f7;
+  border: 1px solid #ddd;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
 
   /* 마우스가 올라갔을 때 살짝 떠오르는 입체감 효과 (선택사항) */
@@ -127,7 +148,7 @@ li.schedule-item {
 
 /* 마우스 호버 시 살짝 강조되는 효과 */
 li.schedule-item:hover {
-  border-color: #cbd5e0;
+  border-color: #b3b3b3;
   box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
 }
 
@@ -152,9 +173,22 @@ li.schedule-item:hover {
   margin-right: 8px;
 }
 
+.todo-checkbox {
+  margin-right: 10px;
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+  accent-color: #10b981;
+}
+
 .event-title {
   color: #10b981;
   font-size: 1.1em;
+}
+
+.event-title.completed {
+  text-decoration: line-through;
+  color: #9ca3af !important;
 }
 
 /* style scoped 맨 아래에 예쁜 초록색 마우스오버 효과 추가 */
@@ -214,6 +248,10 @@ li.schedule-item:hover {
 
 .plant-list {
   margin-top: 8px;
+}
+
+.plant-list.completed {
+  opacity: 0.5;
 }
 
 .plant-badge {

--- a/frontend/src/composables/useCalendarApi.js
+++ b/frontend/src/composables/useCalendarApi.js
@@ -115,6 +115,21 @@ export function useCalendarApi() {
     }
   }
 
+  // 할 일 상태 변경
+  const changeTodoStatus = async (todoId, isDone) => {
+    loading.value = true
+    error.value = null
+    try {
+      const res = await api.patch(`/api/todo/${todoId}/status`, { isDone })
+      return true
+    } catch (err) {
+      console.error('할 일 완료 상태 변경 실패', err)
+      return false
+    } finally {
+      loading.value = false
+    }
+  }
+
   // 할 일 삭제 함수 (DELETE) - soft delete도 delete. 행위의 목적!
   const deleteTodo = async (todoId) => {
     loading.value = true
@@ -244,6 +259,7 @@ export function useCalendarApi() {
     getMemberPlants,
     createTodo,
     updateTodo,
+    changeTodoStatus,
     deleteTodo,
 
     // Diary 관련 액션

--- a/frontend/src/views/CalendarView.vue
+++ b/frontend/src/views/CalendarView.vue
@@ -8,8 +8,15 @@ import { useCalendarApi } from '@/composables/useCalendarApi.js'
 import DiaryFormModal from '@/components/modal/DiaryFormModal.vue'
 
 // 컴포저블 함수에서 상태(allEvents, allDiaries)와 API 호출 함수 가져오기
-const { allEvents, allDiaries, fetchTodoList, fetchDiaryList, deleteTodo, deleteDiary } =
-  useCalendarApi()
+const {
+  allEvents,
+  allDiaries,
+  fetchTodoList,
+  fetchDiaryList,
+  changeTodoStatus,
+  deleteTodo,
+  deleteDiary,
+} = useCalendarApi()
 
 // 오른쪽 탭에 보여줄 기준 날짜 (기본값: 오늘)
 const selectedDate = ref(new Date())
@@ -84,6 +91,16 @@ const processSavedDate = (savedDateStr) => {
 
   // 2. 같은 달인지 여부를 반환 (true면 데이터 새로고침 진행, false면 멈춤)
   return isSameMonth
+}
+
+// 할 일 체크박스 클릭 시 실행할 핸들러
+const handleTodoToggle = async ({ todoId, isDone }) => {
+  const isSuccess = await changeTodoStatus(todoId, isDone)
+  if (isSuccess) {
+    await refreshAllLists()
+  } else {
+    alert('할 일 상태 변경에 실패했습니다.')
+  }
 }
 
 // 할 일 등록 및 수정 완료 시 공통 저장 핸들러
@@ -250,6 +267,7 @@ const selectedDateString = computed(() => formatDateStr(selectedDate.value))
             @open-register="isTodoRegisterModalOpen = true"
             @delete-todo="handleTodoDelete"
             @edit-todo="handleTodoEdit"
+            @toggle-todo="handleTodoToggle"
           />
 
           <!-- '일기' 탭 내용 -->


### PR DESCRIPTION
## 📌 개요
할 일 목록의 완료 상태(isDone)를 관리하기 위한 백엔드 API 구현, 데이터베이스 매핑 보완 및 프론트엔드 UI 연동 작업을 진행했습니다.

## 🛠️ 주요 변경 사항
### 1. 백엔드 API & DB 매핑 구현
- 필드 추가: 할 일 목록 조회 시 완료 여부를 확인할 수 있도록 is_done 필드 추가
- API 구현: 할 일 완료 상태 변경 API 작성 및 단위 테스트/검증 완료
- MyBatis 매핑: 캘린더 조회 resultMap에 is_done 매핑을 추가하여 데이터 누락 방지

### 2. 프론트엔드 UI 연동
- 할 일 완료 상태(isDone) 체크박스 및 상태 변경 기능 프론트 UI 연동

## 🧪 테스트 결과
- 할 일 완료 상태 변경 API 및 조회 기능 테스트 검증 완료
- 프론트엔드 체크박스 클릭 시 DB 상태 변경 및 UI 반영 정상 동작 확인